### PR TITLE
Add extension func for prefix(while:) drop(while:)

### DIFF
--- a/API.swift
+++ b/API.swift
@@ -117,5 +117,9 @@ public func ~= <Root>(keyPath: KeyPath<Root, String>, regex: Predicate.Regex) ->
 extension Sequence {
 
     public func filter(_ predicate: Predicate.Predicate<Self.Element>) -> [Self.Element]
+
+    public func prefix(while predicate: Predicate.Predicate<Self.Element>) -> Self.SubSequence
+
+    public func drop(while predicate: Predicate.Predicate<Self.Element>) -> Self.SubSequence
 }
 

--- a/Sources/Predicate/Sequence/Sequence+Filter.swift
+++ b/Sources/Predicate/Sequence/Sequence+Filter.swift
@@ -1,7 +1,0 @@
-extension Sequence {
-    
-    public func filter(_ predicate: Predicate<Element>) -> [Element] {
-        return filter(predicate.evaluate)
-    }
-    
-}

--- a/Sources/Predicate/Sequence/Sequence+Filtering.swift
+++ b/Sources/Predicate/Sequence/Sequence+Filtering.swift
@@ -1,0 +1,15 @@
+extension Sequence {
+    
+    public func filter(_ predicate: Predicate<Element>) -> [Element] {
+        return filter(predicate.evaluate)
+    }
+    
+    public func prefix(while predicate: Predicate<Element>) -> Self.SubSequence {
+        return prefix(while: predicate.evaluate)
+    }
+    
+    public func drop(while predicate: Predicate<Element>) -> Self.SubSequence {
+        return drop(while: predicate.evaluate)
+    }
+    
+}

--- a/Tests/PredicateTests/Tests.swift
+++ b/Tests/PredicateTests/Tests.swift
@@ -106,6 +106,26 @@ final class PredicateTests: XCTestCase {
         XCTAssertEqual(allUsers.filter(\.name ~= Regex(pattern: "OB$", options: .caseInsensitive)).count, 2) // Bob, Rob
     }
     
+    func test_prefixWhile() {
+        
+        let result = allUsers.prefix(while: \.weight < 85)
+        
+        XCTAssertEqual(result.count, 2) // Bob, Rob
+        XCTAssertEqual(result[result.startIndex].name, "Bob")
+        XCTAssertEqual(result[result.startIndex + 1].name, "Rob")
+        
+    }
+    
+    func test_dropWhile() {
+        
+        let result = allUsers.drop(while: \.age < 35)
+        
+        XCTAssertEqual(result.count, 2) // Rob, Dan
+        XCTAssertEqual(result[result.startIndex].name, "Rob")
+        XCTAssertEqual(result[result.startIndex + 1].name, "Dan")
+        
+    }
+    
     static var allTests = [
         ("test_filter_string_equal", test_filter_string_equal),
         ("test_filter_string_notEqual", test_filter_string_notEqual),
@@ -121,6 +141,8 @@ final class PredicateTests: XCTestCase {
         ("test_filter_chain", test_filter_chain),
         ("test_filter_regex", test_filter_regex),
         ("test_filter_regexCaseInsensitive", test_filter_regexCaseInsensitive),
+        ("test_prefixWhile", test_prefixWhile),
+        ("test_dropWhile", test_dropWhile)
     ]
     
 }


### PR DESCRIPTION
Why:
These two filtering functions should have access to the same predicate
API as `filter`.

This change addresses the need by:
Add functions for `prefix` and `drop`.